### PR TITLE
Logging api requests are now viewable

### DIFF
--- a/env/pip-selfcheck.json
+++ b/env/pip-selfcheck.json
@@ -1,1 +1,1 @@
-{"last_check":"2016-09-14T12:59:03Z","pypi_version":"8.1.2"}
+{"last_check":"2016-09-26T13:16:19Z","pypi_version":"8.1.2"}

--- a/service/categories/views.py
+++ b/service/categories/views.py
@@ -1,5 +1,6 @@
 from slugify import slugify
-from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.generics import GenericAPIView, ListAPIView
+from rest_framework_tracking.mixins import LoggingMixin
 
 from .models import Category
 from .serializers import CategoryListSerializer
@@ -7,7 +8,7 @@ from .serializers import CategoryListSerializer
 # from rest_framework.permissions import IsAuthenticated
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
-class CategoryListAPIView(ListAPIView):
+class CategoryListAPIView(LoggingMixin, ListAPIView):
   """
   Retrieve a list of all categories.
   """
@@ -31,7 +32,7 @@ class CategoryListAPIView(ListAPIView):
 #   queryset = Category.objects.all()
 #   serializer_class = CategoryListSerializer
 
-class CategoryDetailAPIView(ListAPIView):
+class CategoryDetailAPIView(LoggingMixin, ListAPIView):
   """
   Retrive a category and/or subcategory by name. \n
   Delimiter is | between values you want to query by. \n

--- a/service/countries/views.py
+++ b/service/countries/views.py
@@ -1,4 +1,5 @@
 from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework_tracking.mixins import LoggingMixin
 
 from .models import Country
 from .serializers import CountryListSerializer
@@ -6,7 +7,7 @@ from .serializers import CountryListSerializer
 # from rest_framework.permissions import IsAuthenticated
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
-class CountryListAPIView(ListAPIView):
+class CountryListAPIView(LoggingMixin, ListAPIView):
   """
   Retrieve a list of all countries.
   """
@@ -18,7 +19,7 @@ class CountryListAPIView(ListAPIView):
   queryset = Country.objects.all()
   serializer_class = CountryListSerializer
 
-class CountryDetailAPIView(ListAPIView):
+class CountryDetailAPIView(LoggingMixin, ListAPIView):
   """
   Retrive a country by name(s). \n
   Delimiter is | between country names. \n

--- a/service/data/views.py
+++ b/service/data/views.py
@@ -1,4 +1,5 @@
 from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework_tracking.mixins import LoggingMixin
 
 from .models import Data
 from .serializers import DataListSerializer
@@ -14,7 +15,7 @@ from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 #   queryset = Data.objects.all()
 #   serializer_class = DataListSerializer
 
-class CountryDataAPIView(ListAPIView):
+class CountryDataAPIView(LoggingMixin, ListAPIView):
   """
   Retrive a country's data for a specific indicator - default for all years. \n
   Delimiter is | between all the values in your parameters for each variable. \n

--- a/service/indicators/views.py
+++ b/service/indicators/views.py
@@ -1,4 +1,5 @@
 from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework_tracking.mixins import LoggingMixin
 
 from .models import Indicator
 from .serializers import IndicatorListSerializer
@@ -6,7 +7,7 @@ from .serializers import IndicatorListSerializer
 # from rest_framework.permissions import IsAuthenticated
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
-class IndicatorListAPIView(ListAPIView):
+class IndicatorListAPIView(LoggingMixin, ListAPIView):
   """
   Retrieve a list of all indicators.
   """
@@ -17,7 +18,7 @@ class IndicatorListAPIView(ListAPIView):
   queryset = Indicator.objects.all()
   serializer_class = IndicatorListSerializer
 
-class IndicatorDetailAPIView(ListAPIView):
+class IndicatorDetailAPIView(LoggingMixin, ListAPIView):
   """
   Retrive a indicator by name. \n
   Delimiter is | between all the values in your parameters for each variable. \n

--- a/service/region_data/views.py
+++ b/service/region_data/views.py
@@ -1,4 +1,5 @@
 from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework_tracking.mixins import LoggingMixin
 
 from .models import RegionData
 from .serializers import RegionDataListSerializer
@@ -6,7 +7,7 @@ from .serializers import RegionDataListSerializer
 # from rest_framework.permissions import IsAuthenticated
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
-class RegionDataAPIView(ListAPIView):
+class RegionDataAPIView(LoggingMixin, ListAPIView):
   """
   Retrive a region(s)' data for a specific indicator - default for all years. \n
   Delimiter is | between all the values in your parameters for each variable. \n

--- a/service/regions/views.py
+++ b/service/regions/views.py
@@ -1,4 +1,5 @@
 from rest_framework.generics import ListAPIView
+from rest_framework_tracking.mixins import LoggingMixin
 
 from .models import Region
 from .serializers import RegionListSerializer
@@ -6,7 +7,7 @@ from .serializers import RegionListSerializer
 # from rest_framework.permissions import IsAuthenticated
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
-class RegionListAPIView(ListAPIView):
+class RegionListAPIView(LoggingMixin, ListAPIView):
   """
   Retrieve a list of all indicators.
   """
@@ -18,7 +19,7 @@ class RegionListAPIView(ListAPIView):
   queryset = Region.objects.all()
   serializer_class = RegionListSerializer
 
-class RegionDetailAPIView(ListAPIView):
+class RegionDetailAPIView(LoggingMixin, ListAPIView):
   """
   Retrive a region by id(s). \n
   Delimiter is | between all the values in your parameters for each variable. \n


### PR DESCRIPTION
Administrators can view in the admin dashboard who is requesting the api.
This is a major functionality so that we can track IPs requesting and what users are requesting the api endpoints.
If we need to revoke the user's access we can do so based on the statistics we are logging.
